### PR TITLE
docs: removing Helm Charts from the primary radar

### DIFF
--- a/radars/primary/quadrants/technologies/rings/provisional/blips/helm-charts.json
+++ b/radars/primary/quadrants/technologies/rings/provisional/blips/helm-charts.json
@@ -1,7 +1,0 @@
-{
-  "name": "Helm Charts",
-  "ring": "Provisional",
-  "quadrant": "Technologies",
-  "isNew": "",
-  "description": "Helm Charts are Kubernetes YAML manifests combined into a single package. edX.org uses many open source helm charts so they can easily deploy and update services into their Kubernetes clusters. In addition edX.org has experimented with creating their own charts to ensure we consistently deploy Django services."
-}


### PR DESCRIPTION
We've decided that Helm Charts should be moved to the "edX-specific" radar, which isn't in this repository yet.  So this deletes it.