### PR TITLE
Tutor should actually be marked as accepted by now

### DIFF
--- a/radars/primary/quadrants/open-edx/rings/provisional/blips/tutor.json
+++ b/radars/primary/quadrants/open-edx/rings/provisional/blips/tutor.json
@@ -1,6 +1,6 @@
 {
   "name": "Tutor",
-  "ring": "Provisional",
+  "ring": "Accepted",
   "quadrant": "Open edX",
   "isNew": "",
   "description": "A Blip: Docker based development and deployment environment for Open edX.  Already an officially supported deployment option, it is likely to become the official development environment also in the near future (replacing Blip: devstack)."


### PR DESCRIPTION
Tutor is the default community installation as of Maple, so it is no longer
"provisional".

See: https://discuss.openedx.org/t/tech-radar-beta-last-call-for-reviewers/5980/8