### PR TITLE
feat: add style-dictionary to tech radar as provisional, deprecate Enzyme

### DIFF
--- a/radars/primary/quadrants/frontend/blips/enzyme.json
+++ b/radars/primary/quadrants/frontend/blips/enzyme.json
@@ -1,7 +1,7 @@
 {
   "name": "enzyme",
-  "ring": "Accepted",
+  "ring": "Hold",
   "quadrant": "Frontend",
   "isNew": "",
-  "description": "React component testing library with a particular focus on snapshots and class components.\nWe use this in some MFEs for React unit testing.  Our recommendation is to move away from using enzyme for component testing, and suggest using Blip: testing-library instead.  Enzyme has a more complex set of testing primitives than testing-library, (subjectively) making it a bit harder to reason with. Blip: testing-library has a simpler API, promotes standard ways of querying the DOM, and helps us keep our code accessible by encouraging a11y/ARIA-based querying for writing expectations/assertions."
+  "description": "React component testing library with a particular focus on snapshots and class components.\nWe use this in some MFEs for React unit testing.  Our recommendation is to move away from using enzyme for component testing, and suggest using Blip: testing-library instead.  Enzyme has a more complex set of testing primitives than testing-library, (subjectively) making it a bit harder to reason with. Blip: testing-library has a simpler API, promotes standard ways of querying the DOM, and helps us keep our code accessible by encouraging a11y/ARIA-based querying for writing expectations/assertions. No longer maintained; deprecated."
 }

--- a/radars/primary/quadrants/frontend/blips/ie-11-support.json
+++ b/radars/primary/quadrants/frontend/blips/ie-11-support.json
@@ -3,5 +3,5 @@
   "ring": "Hold",
   "quadrant": "Frontend",
   "isNew": "",
-  "description": "We continue to support IE 11 in the near term because edx.org and edX for Business continues to have a number of partners and customers which depend on the browser.  We are actively working with partners to cut over to more modern browsers so we can drop support.  Doing so will allow us to simplify build processes (e.g., transpile less code) and use more modern browser features.  The industry is quickly moving away from IE11, as Microsoft itself has signaled their intention to stop supporting it in Microsoft 365 applications in 2021 and officially dropping support for IE11 in Windows 10 in June 2022."
+  "description": "We no longer officially support IE 11, as Microsoft itself stopped supporting it in Microsoft 365 applications in 2021 and officially dropped support for it in Windows 10 in June 2022."
 }

--- a/radars/primary/quadrants/frontend/blips/style-dictionary.json
+++ b/radars/primary/quadrants/frontend/blips/style-dictionary.json
@@ -1,0 +1,7 @@
+{
+  "name": "style-dictionary",
+  "ring": "Provisional",
+  "quadrant": "Frontend",
+  "isNew": "",
+  "description": "A build system for creating cross-platform styles through design tokens. Used by Paragon design component and React component library, amongst other projects."
+}

--- a/radars/primary/quadrants/frontend/blips/style-dictionary.json
+++ b/radars/primary/quadrants/frontend/blips/style-dictionary.json
@@ -2,6 +2,6 @@
   "name": "style-dictionary",
   "ring": "Provisional",
   "quadrant": "Frontend",
-  "isNew": "",
+  "isNew": "TRUE",
   "description": "A build system for creating cross-platform styles through design tokens. Used by Paragon design component and React component library, amongst other projects."
 }


### PR DESCRIPTION
* Updates Enzyme to "Hold" (it's [deprecated](https://github.com/openedx/public-engineering/issues/195) in Open edX).
* Updates the description of "IE 11 support" to make it more accurately reflect current times in 2023.
* Add `style-dictionary` as provisional. See [Design Tokens ADR](https://github.com/openedx/paragon/blob/master/docs/decisions/0019-scaling-styles-with-design-tokens.rst) for more details.